### PR TITLE
Correct testParser_v1_AllParamsPresent to not depend on HashSet iteration order

### DIFF
--- a/bt-tests/src/test/java/bt/magnet/MagnetUriParserTest.java
+++ b/bt-tests/src/test/java/bt/magnet/MagnetUriParserTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 import static bt.TestUtil.assertExceptionWithMessage;
 import static org.junit.Assert.assertArrayEquals;
@@ -53,10 +55,11 @@ public class MagnetUriParserTest {
         assertTrue(trackerUrls.contains(trackerUrl2));
 
         Collection<InetPeerAddress> peerAddresses = uri.getPeerAddresses();
-        assertEquals(2, peerAddresses.size());
-        Iterator<InetPeerAddress> iter = peerAddresses.iterator();
-        assertEquals(new InetPeerAddress("1.1.1.1", 10000), iter.next());
-        assertEquals(new InetPeerAddress("2.2.2.2", 10000), iter.next());
+        Set<InetPeerAddress> expectedPeers = new HashSet<>(Arrays.asList(
+            new InetPeerAddress("1.1.1.1", 10000),
+            new InetPeerAddress("2.2.2.2", 10000)
+        ));
+        assertEquals(new HashSet<>(expectedPeers), peerAddresses);
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR updates `testParser_v1_AllParamsPresent` in `bt-tests` to use a direct comparison for peer addresses.

Previously, the test compared `InetPeerAddress` values by iterating over `peerAddresses` in order. However, `MagnetUri.getPeerAddresses()` returns a `Collection` backed by a `Set`, which does not guarantee iteration order. This could cause nondeterministic test failures depending on the JVM or hash distribution.

## Changes made
- Defined `expectedPeers` as a `Collection` and compared it with the result `peerAddresses` to remove reliance on iteration order, but still ensuring returned contents are correct.
```java
Collection<InetPeerAddress> expectedPeers = Set.of(
    new InetPeerAddress("1.1.1.1", 10000),
    new InetPeerAddress("2.2.2.2", 10000)
);

...

assertEquals(expectedPeers, peerAddresses);
```
- Ensures correctness by verifying the presence of all expected peers without depending on iteration order.

## Rationale
- Prevents false negatives in tests due to nondeterministic ordering.
- Makes the test aligned with the API contract (order not specified).
- Improves stability and portability of the test suite.